### PR TITLE
Raises appropriate error when image is not found

### DIFF
--- a/ims/database/image.py
+++ b/ims/database/image.py
@@ -141,8 +141,11 @@ class ImageRepository:
             image = self.connection.session.query(Image). \
                 filter(Image.project.has(name=project_name)).filter_by(
                 name=name).one_or_none()
-            if image is not None:
-                return image.id
+
+            if image is None:
+                raise db_exceptions.ImageNotFoundException(name)
+
+            return image.id
         except SQLAlchemyError as e:
             raise db_exceptions.ORMException(e.message)
 

--- a/ims/database/image.py
+++ b/ims/database/image.py
@@ -137,7 +137,13 @@ class ImageRepository:
     # returns a array of image ids of the images which have the given name
     @log
     def fetch_id_with_name_from_project(self, name, project_name):
-        """searches for image by name and returns image id"""
+        """
+        searches for image by name and returns image id
+
+        :param  name: name of the image
+        :poaram project_name: name of the project
+        :return: image.id: the image id of the image
+        """
 
         try:
             image = self.connection.session.query(Image). \

--- a/ims/database/image.py
+++ b/ims/database/image.py
@@ -138,11 +138,11 @@ class ImageRepository:
     @log
     def fetch_id_with_name_from_project(self, name, project_name):
         """
-        searches for image by name and returns image id
+        Searches for image by name and returns image id
 
-        :param  name: name of the image
-        :poaram project_name: name of the project
-        :return: image.id: the image id of the image
+        :param name: name of the image
+        :param project_name: name of the project
+        :return: the id of the image.
         """
 
         try:

--- a/ims/database/image.py
+++ b/ims/database/image.py
@@ -137,14 +137,14 @@ class ImageRepository:
     # returns a array of image ids of the images which have the given name
     @log
     def fetch_id_with_name_from_project(self, name, project_name):
+        """searches for image by name and returns image id"""
+
         try:
             image = self.connection.session.query(Image). \
                 filter(Image.project.has(name=project_name)).filter_by(
                 name=name).one_or_none()
-
             if image is None:
                 raise db_exceptions.ImageNotFoundException(name)
-
             return image.id
         except SQLAlchemyError as e:
             raise db_exceptions.ORMException(e.message)

--- a/tests/unit/database/test_image.py
+++ b/tests/unit/database/test_image.py
@@ -6,7 +6,6 @@ config.load()
 from ims.common.log import trace
 from ims.database.database import Database
 from ims.exception import db_exceptions
-import pytest
 
 
 class TestInsert(TestCase):
@@ -71,7 +70,7 @@ class TestFetch(TestCase):
         self.db.image.insert('image 3', 1, parent_id=1)
         self.db.image.insert('image 4', 1, is_snapshot=True, parent_id=1)
 
-    def runTest(self):
+    def test_image_fetch(self):
         images = self.db.image.fetch_images_from_project('project 1')
         self.assertTrue('image 1' in images and 'image 2' in images)
 
@@ -91,14 +90,18 @@ class TestFetch(TestCase):
                                                                'project 1')
         self.assertEqual(img_id, 2)
 
-        with pytest.raises(db_exceptions.ImageNotFoundException):
-            img_id = self.db.image.fetch_id_with_name_from_project(
-                'some_', 'project 1')
-
         images = self.db.image.fetch_all_images()
         self.assertEqual(images.__len__(), 4)
         self.assertEqual([image[1] for image in images],
                          ['image 1', 'image 2', 'image 3', 'image 4'])
+
+    def test_nonexistent_image_fetch(self):
+        """tries to retrieve the image id of an image that doesn't
+        exist in the db. should raise an error"""
+
+        with self.assertRaises(db_exceptions.ImageNotFoundException):
+            img_id = self.db.image.fetch_id_with_name_from_project(
+                'nonexistent_image', 'project 1')
 
     def tearDown(self):
         self.db.project.delete_with_name('project 1')

--- a/tests/unit/database/test_image.py
+++ b/tests/unit/database/test_image.py
@@ -5,6 +5,8 @@ config.load()
 
 from ims.common.log import trace
 from ims.database.database import Database
+from ims.exception import db_exceptions
+import pytest
 
 
 class TestInsert(TestCase):
@@ -88,6 +90,10 @@ class TestFetch(TestCase):
         img_id = self.db.image.fetch_id_with_name_from_project('image 2',
                                                                'project 1')
         self.assertEqual(img_id, 2)
+
+        with pytest.raises(db_exceptions.ImageNotFoundException):
+            img_id = self.db.image.fetch_id_with_name_from_project(
+                        'some_', 'project 1')
 
         images = self.db.image.fetch_all_images()
         self.assertEqual(images.__len__(), 4)

--- a/tests/unit/database/test_image.py
+++ b/tests/unit/database/test_image.py
@@ -96,8 +96,10 @@ class TestFetch(TestCase):
                          ['image 1', 'image 2', 'image 3', 'image 4'])
 
     def test_nonexistent_image_fetch(self):
-        """tries to retrieve the image id of an image that doesn't
-        exist in the db. should raise an error"""
+        """
+        Tries to retrieve the image id of an image that doesn't
+        exist in the db. Should raise an error
+        """
 
         with self.assertRaises(db_exceptions.ImageNotFoundException):
             img_id = self.db.image.fetch_id_with_name_from_project(

--- a/tests/unit/database/test_image.py
+++ b/tests/unit/database/test_image.py
@@ -93,7 +93,7 @@ class TestFetch(TestCase):
 
         with pytest.raises(db_exceptions.ImageNotFoundException):
             img_id = self.db.image.fetch_id_with_name_from_project(
-                        'some_', 'project 1')
+                'some_', 'project 1')
 
         images = self.db.image.fetch_all_images()
         self.assertEqual(images.__len__(), 4)


### PR DESCRIPTION
Addresses #91 and a little bit of #57 

Now if the image name we give is not in the database, we handle it correctly. 