### PR TITLE
In memory DB for tests

### DIFF
--- a/ims/database/db_connection.py
+++ b/ims/database/db_connection.py
@@ -4,9 +4,13 @@ from sqlalchemy.orm import sessionmaker
 from sqlalchemy.pool import SingletonThreadPool
 
 import ims.common.config as config
-import ims.common.constants as constants
 
 _cfg = config.get()
+
+# creates the engine for the database
+# Should be adapted to postgres SQL
+engine = create_engine('sqlite:///' + _cfg.db.path,
+                       poolclass=SingletonThreadPool)
 
 
 # The class which represents the BMI database
@@ -15,22 +19,13 @@ class DatabaseConnection:
     # the sqlalchemy base class which the table classes will inherit
     Base = declarative_base()
 
-    # the engine and session maker are made static so that only one of them
-    # needs to be created
-    # creates the engine for the database
-    # sample_bmi.db should be changed to something more realistic
-    # NullPool pool class is equivalent to no connection pool
-    # Should be adapted to postgres SQL
-    engine = create_engine('sqlite:///' + _cfg.db.path,
-                           poolclass=SingletonThreadPool)
-
-    # creates a session maker for creating sessions
-    session_maker = sessionmaker(bind=engine)
-
     # creates all tables if not present
     def __init__(self):
-        DatabaseConnection.Base.metadata.create_all(DatabaseConnection.engine)
-        self.session = DatabaseConnection.session_maker()
+        # creates a session maker for creating sessions
+        session_maker = sessionmaker(bind=engine)
+
+        DatabaseConnection.Base.metadata.create_all(engine)
+        self.session = session_maker()
 
     def close(self):
         self.session.close()


### PR DESCRIPTION
Issues #107 and #35 
Allows to create in memory for tests. Just set db path in config to :memory: and run tests normally.

Also it creates engine only once now.

The current issue is all tests run well except test_rest.py these run against picasso and einstein which create a separate in memory db as they are separate processes and the test process creates a separate db. Any ideas on how to resolve this ?