### PR TITLE
Hil flag for Secure Cloud

### DIFF
--- a/ims/cli/cli.py
+++ b/ims/cli/cli.py
@@ -63,14 +63,14 @@ def cli():
 
 
 @cli.command(name='pro', short_help="Provision a Node")
-@click.option(constants.HIL_OPTION_PARAMETER, default=True,
-              help="enable/disable HIL functionality within BMI")
 @click.argument(constants.PROJECT_PARAMETER)
 @click.argument(constants.NODE_NAME_PARAMETER)
 @click.argument(constants.IMAGE_NAME_PARAMETER)
 @click.argument(constants.NETWORK_PARAMETER)
 @click.argument(constants.NIC_PARAMETER)
-def provision(hil, project, node, img, network, nic):
+@click.option(constants.HIL_OPTION_PARAMETER, default=True,
+              help="enable/disable HIL functionality within BMI")
+def provision(project, node, img, network, nic, hil):
     """
     Provision a Node
 
@@ -83,25 +83,25 @@ def provision(hil, project, node, img, network, nic):
     CHANNEL = The Channel to Provision On (For HIL It is 'vlan/native')
     NIC     = The NIC to use for Network Boot (For HIL IT is 'enp130s0f0')
     """
-    data = {constants.HIL_OPTION_PARAMETER: hil,
-            constants.PROJECT_PARAMETER: project,
+    data = {constants.PROJECT_PARAMETER: project,
             constants.NODE_NAME_PARAMETER: node,
             constants.IMAGE_NAME_PARAMETER: img,
             constants.NETWORK_PARAMETER: network,
-            constants.NIC_PARAMETER: nic}
+            constants.NIC_PARAMETER: nic,
+            constants.HIL_OPTION_PARAMETER: hil}
     res = requests.put(_url + "provision/", data=data,
                        auth=(_username, _password))
     click.echo(res.content)
 
 
 @cli.command(name='dpro', short_help='Deprovision a node')
-@click.option(constants.HIL_OPTION_PARAMETER, default=True,
-              help="enable/disable HIL functionality within BMI")
 @click.argument(constants.PROJECT_PARAMETER)
 @click.argument(constants.NODE_NAME_PARAMETER)
 @click.argument(constants.NETWORK_PARAMETER)
 @click.argument(constants.NIC_PARAMETER)
-def deprovision(hil, project, node, network, nic):
+@click.option(constants.HIL_OPTION_PARAMETER, default=True,
+              help="enable/disable HIL functionality within BMI")
+def deprovision(project, node, network, nic, hil):
     """
     Deprovision a Node
 
@@ -112,11 +112,11 @@ def deprovision(hil, project, node, network, nic):
     NETWORK = The Name of the Provisioning Network
     NIC     = The NIC that was used for Network Boot
     """
-    data = {constants.HIL_OPTION_PARAMETER: hil,
-            constants.PROJECT_PARAMETER: project,
+    data = {constants.PROJECT_PARAMETER: project,
             constants.NODE_NAME_PARAMETER: node,
             constants.NETWORK_PARAMETER: network,
-            constants.NIC_PARAMETER: nic}
+            constants.NIC_PARAMETER: nic,
+            constants.HIL_OPTION_PARAMETER: hil}
     res = requests.delete(_url + "deprovision/", data=data, auth=(
         _username, _password))
     click.echo(res.content)

--- a/ims/cli/cli.py
+++ b/ims/cli/cli.py
@@ -70,7 +70,7 @@ def cli():
 @click.argument(constants.IMAGE_NAME_PARAMETER)
 @click.argument(constants.NETWORK_PARAMETER)
 @click.argument(constants.NIC_PARAMETER)
-def provision(hil_flag, project, node, img, network, nic):
+def provision(hil, project, node, img, network, nic):
     """
     Provision a Node
 
@@ -83,7 +83,7 @@ def provision(hil_flag, project, node, img, network, nic):
     CHANNEL = The Channel to Provision On (For HIL It is 'vlan/native')
     NIC     = The NIC to use for Network Boot (For HIL IT is 'enp130s0f0')
     """
-    data = {constants.HIL_OPTION_PARAMETER: hil_flag,
+    data = {constants.HIL_OPTION_PARAMETER: hil,
             constants.PROJECT_PARAMETER: project,
             constants.NODE_NAME_PARAMETER: node,
             constants.IMAGE_NAME_PARAMETER: img,
@@ -101,7 +101,7 @@ def provision(hil_flag, project, node, img, network, nic):
 @click.argument(constants.NODE_NAME_PARAMETER)
 @click.argument(constants.NETWORK_PARAMETER)
 @click.argument(constants.NIC_PARAMETER)
-def deprovision(hil_flag, project, node, network, nic):
+def deprovision(hil, project, node, network, nic):
     """
     Deprovision a Node
 
@@ -112,7 +112,7 @@ def deprovision(hil_flag, project, node, network, nic):
     NETWORK = The Name of the Provisioning Network
     NIC     = The NIC that was used for Network Boot
     """
-    data = {constants.HIL_OPTION_PARAMETER: hil_flag,
+    data = {constants.HIL_OPTION_PARAMETER: hil,
             constants.PROJECT_PARAMETER: project,
             constants.NODE_NAME_PARAMETER: node,
             constants.NETWORK_PARAMETER: network,

--- a/ims/cli/cli.py
+++ b/ims/cli/cli.py
@@ -63,12 +63,14 @@ def cli():
 
 
 @cli.command(name='pro', short_help="Provision a Node")
+@click.option(constants.HIL_OPTION_PARAMETER, default=True,
+              help="enable/disable HIL functionality within BMI")
 @click.argument(constants.PROJECT_PARAMETER)
 @click.argument(constants.NODE_NAME_PARAMETER)
 @click.argument(constants.IMAGE_NAME_PARAMETER)
 @click.argument(constants.NETWORK_PARAMETER)
 @click.argument(constants.NIC_PARAMETER)
-def provision(project, node, img, network, nic):
+def provision(hil_flag, project, node, img, network, nic):
     """
     Provision a Node
 
@@ -81,7 +83,8 @@ def provision(project, node, img, network, nic):
     CHANNEL = The Channel to Provision On (For HIL It is 'vlan/native')
     NIC     = The NIC to use for Network Boot (For HIL IT is 'enp130s0f0')
     """
-    data = {constants.PROJECT_PARAMETER: project,
+    data = {constants.HIL_OPTION_PARAMETER: hil_flag,
+            constants.PROJECT_PARAMETER: project,
             constants.NODE_NAME_PARAMETER: node,
             constants.IMAGE_NAME_PARAMETER: img,
             constants.NETWORK_PARAMETER: network,
@@ -92,11 +95,13 @@ def provision(project, node, img, network, nic):
 
 
 @cli.command(name='dpro', short_help='Deprovision a node')
+@click.option(constants.HIL_OPTION_PARAMETER, default=True,
+              help="enable/disable HIL functionality within BMI")
 @click.argument(constants.PROJECT_PARAMETER)
 @click.argument(constants.NODE_NAME_PARAMETER)
 @click.argument(constants.NETWORK_PARAMETER)
 @click.argument(constants.NIC_PARAMETER)
-def deprovision(project, node, network, nic):
+def deprovision(hil_flag, project, node, network, nic):
     """
     Deprovision a Node
 
@@ -107,7 +112,8 @@ def deprovision(project, node, network, nic):
     NETWORK = The Name of the Provisioning Network
     NIC     = The NIC that was used for Network Boot
     """
-    data = {constants.PROJECT_PARAMETER: project,
+    data = {constants.HIL_OPTION_PARAMETER: hil_flag,
+            constants.PROJECT_PARAMETER: project,
             constants.NODE_NAME_PARAMETER: node,
             constants.NETWORK_PARAMETER: network,
             constants.NIC_PARAMETER: nic}

--- a/ims/common/constants.py
+++ b/ims/common/constants.py
@@ -103,6 +103,7 @@ NETWORK_PARAMETER = "network"
 NIC_PARAMETER = "nic"
 CHANNEL_PARAMETER = "channel"
 SCRIPT_PATH_PARAMETER = "script"
+HIL_OPTION_PARAMETER = "--hil/--no-hil"
 
 # Template Parameters
 IPXE_TARGET_NAME = "${target_name}"

--- a/ims/einstein/operations.py
+++ b/ims/einstein/operations.py
@@ -219,10 +219,12 @@ class BMI:
     @log
     def provision(self, hil_flag, node_name, img_name, network, nic):
         try:
+            hil_bool = bool(hil_flag == "True")
+
             mac_addr = "01-" + self.hil.get_node_mac_addr(node_name). \
                 replace(":", "-")
 
-            if hil_flag:
+            if hil_bool:
                 self.hil.attach_node_to_project_network(node_name, network,
                                                         nic)
 
@@ -250,7 +252,7 @@ class BMI:
             self.fs.remove(clone_ceph_name)
             self.db.image.delete_with_name_from_project(node_name, self.proj)
             time.sleep(constants.HAAS_CALL_TIMEOUT)
-            if hil_flag:
+            if hil_bool:
                 self.hil.detach_node_from_project_network(node_name, network,
                                                           nic)
             return self.__return_error(e)
@@ -262,7 +264,7 @@ class BMI:
             self.fs.remove(clone_ceph_name)
             self.db.image.delete_with_name_from_project(node_name, self.proj)
             time.sleep(constants.HAAS_CALL_TIMEOUT)
-            if hil_flag:
+            if hil_bool:
                 self.hil.detach_node_from_project_network(node_name, network,
                                                           nic)
             return self.__return_error(e)
@@ -272,7 +274,7 @@ class BMI:
             logger.exception('')
             self.db.image.delete_with_name_from_project(node_name, self.proj)
             time.sleep(constants.HAAS_CALL_TIMEOUT)
-            if hil_flag:
+            if hil_bool:
                 self.hil.detach_node_from_project_network(node_name, network,
                                                           nic)
             return self.__return_error(e)
@@ -280,7 +282,7 @@ class BMI:
             # Message is being handled by custom formatter
             logger.exception('')
             time.sleep(constants.HAAS_CALL_TIMEOUT)
-            if hil_flag:
+            if hil_bool:
                 self.hil.detach_node_from_project_network(node_name, network,
                                                           nic)
             return self.__return_error(e)
@@ -295,7 +297,8 @@ class BMI:
     def deprovision(self, hil_flag, node_name, network, nic):
         ceph_img_name = None
         try:
-            if hil_flag:
+            hil_bool = bool(hil_flag == "True")
+            if hil_bool:
                 self.hil.detach_node_from_project_network(node_name,
                                                           network, nic)
             ceph_img_name = self.__get_ceph_image_name(node_name)
@@ -318,7 +321,7 @@ class BMI:
             self.db.image.insert(node_name, self.pid, parent_id,
                                  id=self.__extract_id(ceph_img_name))
             time.sleep(constants.HAAS_CALL_TIMEOUT)
-            if hil_flag:
+            if hil_bool:
                 self.hil.attach_node_to_project_network(node_name,
                                                         network, nic)
             return self.__return_error(e)
@@ -331,14 +334,14 @@ class BMI:
             self.db.image.insert(node_name, self.pid, parent_id,
                                  id=self.__extract_id(ceph_img_name))
             time.sleep(constants.HAAS_CALL_TIMEOUT)
-            if hil_flag:
+            if hil_bool:
                 self.hil.attach_node_to_project_network(node_name,
                                                         network, nic)
             return self.__return_error(e)
         except DBException as e:
             logger.exception('')
             time.sleep(constants.HAAS_CALL_TIMEOUT)
-            if hil_flag:
+            if hil_bool:
                 self.hil.attach_node_to_project_network(node_name,
                                                         network, nic)
             return self.__return_error(e)

--- a/ims/einstein/operations.py
+++ b/ims/einstein/operations.py
@@ -319,7 +319,7 @@ class BMI:
                                  id=self.__extract_id(ceph_img_name))
             time.sleep(constants.HAAS_CALL_TIMEOUT)
             if hil_flag:
-                self.hil.attach_node_to_project_network(node_name, 
+                self.hil.attach_node_to_project_network(node_name,
                                                         network, nic)
             return self.__return_error(e)
         except ISCSIException as e:
@@ -332,14 +332,14 @@ class BMI:
                                  id=self.__extract_id(ceph_img_name))
             time.sleep(constants.HAAS_CALL_TIMEOUT)
             if hil_flag:
-                self.hil.attach_node_to_project_network(node_name, 
+                self.hil.attach_node_to_project_network(node_name,
                                                         network, nic)
             return self.__return_error(e)
         except DBException as e:
             logger.exception('')
             time.sleep(constants.HAAS_CALL_TIMEOUT)
             if hil_flag:
-                self.hil.attach_node_to_project_network(node_name, 
+                self.hil.attach_node_to_project_network(node_name,
                                                         network, nic)
             return self.__return_error(e)
         except HaaSException as e:

--- a/ims/einstein/operations.py
+++ b/ims/einstein/operations.py
@@ -217,7 +217,7 @@ class BMI:
 
     # Provisions from HaaS and Boots the given node with given image
     @log
-    def provision(self, hil_flag, node_name, img_name, network, nic):
+    def provision(self, node_name, img_name, network, nic, hil_flag):
         try:
             hil_bool = bool(hil_flag == "True")
 
@@ -294,7 +294,7 @@ class BMI:
     # This is for detach a node and removing it from iscsi
     # and destroying its image
     @log
-    def deprovision(self, hil_flag, node_name, network, nic):
+    def deprovision(self, node_name, network, nic, hil_flag):
         ceph_img_name = None
         try:
             hil_bool = bool(hil_flag == "True")

--- a/ims/einstein/operations.py
+++ b/ims/einstein/operations.py
@@ -217,11 +217,14 @@ class BMI:
 
     # Provisions from HaaS and Boots the given node with given image
     @log
-    def provision(self, node_name, img_name, network, nic):
+    def provision(self, hil_flag, node_name, img_name, network, nic):
         try:
             mac_addr = "01-" + self.hil.get_node_mac_addr(node_name). \
                 replace(":", "-")
-            self.hil.attach_node_to_project_network(node_name, network, nic)
+
+            if hil_flag:
+                self.hil.attach_node_to_project_network(node_name, network,
+                                                        nic)
 
             parent_id = self.db.image.fetch_id_with_name_from_project(img_name,
                                                                       self.proj
@@ -247,8 +250,9 @@ class BMI:
             self.fs.remove(clone_ceph_name)
             self.db.image.delete_with_name_from_project(node_name, self.proj)
             time.sleep(constants.HAAS_CALL_TIMEOUT)
-            self.hil.detach_node_from_project_network(node_name, network,
-                                                      nic)
+            if hil_flag:
+                self.hil.detach_node_from_project_network(node_name, network,
+                                                          nic)
             return self.__return_error(e)
 
         except ISCSIException as e:
@@ -258,8 +262,9 @@ class BMI:
             self.fs.remove(clone_ceph_name)
             self.db.image.delete_with_name_from_project(node_name, self.proj)
             time.sleep(constants.HAAS_CALL_TIMEOUT)
-            self.hil.detach_node_from_project_network(node_name, network,
-                                                      nic)
+            if hil_flag:
+                self.hil.detach_node_from_project_network(node_name, network,
+                                                          nic)
             return self.__return_error(e)
 
         except FileSystemException as e:
@@ -267,15 +272,17 @@ class BMI:
             logger.exception('')
             self.db.image.delete_with_name_from_project(node_name, self.proj)
             time.sleep(constants.HAAS_CALL_TIMEOUT)
-            self.hil.detach_node_from_project_network(node_name, network,
-                                                      nic)
+            if hil_flag:
+                self.hil.detach_node_from_project_network(node_name, network,
+                                                          nic)
             return self.__return_error(e)
         except DBException as e:
             # Message is being handled by custom formatter
             logger.exception('')
             time.sleep(constants.HAAS_CALL_TIMEOUT)
-            self.hil.detach_node_from_project_network(node_name, network,
-                                                      nic)
+            if hil_flag:
+                self.hil.detach_node_from_project_network(node_name, network,
+                                                          nic)
             return self.__return_error(e)
         except HaaSException as e:
             # Message is being handled by custom formatter
@@ -285,11 +292,12 @@ class BMI:
     # This is for detach a node and removing it from iscsi
     # and destroying its image
     @log
-    def deprovision(self, node_name, network, nic):
+    def deprovision(self, hil_flag, node_name, network, nic):
         ceph_img_name = None
         try:
-            self.hil.detach_node_from_project_network(node_name,
-                                                      network, nic)
+            if hil_flag:
+                self.hil.detach_node_from_project_network(node_name,
+                                                          network, nic)
             ceph_img_name = self.__get_ceph_image_name(node_name)
             self.db.image.delete_with_name_from_project(node_name, self.proj)
             ceph_config = self.cfg.fs
@@ -310,7 +318,9 @@ class BMI:
             self.db.image.insert(node_name, self.pid, parent_id,
                                  id=self.__extract_id(ceph_img_name))
             time.sleep(constants.HAAS_CALL_TIMEOUT)
-            self.hil.attach_node_to_project_network(node_name, network, nic)
+            if hil_flag:
+                self.hil.attach_node_to_project_network(node_name, 
+                                                        network, nic)
             return self.__return_error(e)
         except ISCSIException as e:
             logger.exception('')
@@ -321,12 +331,16 @@ class BMI:
             self.db.image.insert(node_name, self.pid, parent_id,
                                  id=self.__extract_id(ceph_img_name))
             time.sleep(constants.HAAS_CALL_TIMEOUT)
-            self.hil.attach_node_to_project_network(node_name, network, nic)
+            if hil_flag:
+                self.hil.attach_node_to_project_network(node_name, 
+                                                        network, nic)
             return self.__return_error(e)
         except DBException as e:
             logger.exception('')
             time.sleep(constants.HAAS_CALL_TIMEOUT)
-            self.hil.attach_node_to_project_network(node_name, network, nic)
+            if hil_flag:
+                self.hil.attach_node_to_project_network(node_name, 
+                                                        network, nic)
             return self.__return_error(e)
         except HaaSException as e:
             logger.exception('')

--- a/ims/picasso/rest.py
+++ b/ims/picasso/rest.py
@@ -82,15 +82,16 @@ def list_images():
 
 
 @rest_call("/provision/", 'PUT', constants.PROVISION_COMMAND,
-           [constants.NODE_NAME_PARAMETER, constants.IMAGE_NAME_PARAMETER,
-            constants.NETWORK_PARAMETER, constants.NIC_PARAMETER])
+           [constants.HIL_OPTION_PARAMETER, constants.NODE_NAME_PARAMETER,
+            constants.IMAGE_NAME_PARAMETER, constants.NETWORK_PARAMETER,
+            constants.NIC_PARAMETER])
 def provision():
     pass
 
 
 @rest_call("/deprovision/", "DELETE", constants.DEPROVISION_COMMAND,
-           [constants.NODE_NAME_PARAMETER, constants.NETWORK_PARAMETER,
-            constants.NIC_PARAMETER])
+           [constants.HIL_OPTION_PARAMETER, constants.NODE_NAME_PARAMETER, 
+            constants.NETWORK_PARAMETER, constants.NIC_PARAMETER])
 def deprovision():
     pass
 

--- a/ims/picasso/rest.py
+++ b/ims/picasso/rest.py
@@ -90,7 +90,7 @@ def provision():
 
 
 @rest_call("/deprovision/", "DELETE", constants.DEPROVISION_COMMAND,
-           [constants.HIL_OPTION_PARAMETER, constants.NODE_NAME_PARAMETER, 
+           [constants.HIL_OPTION_PARAMETER, constants.NODE_NAME_PARAMETER,
             constants.NETWORK_PARAMETER, constants.NIC_PARAMETER])
 def deprovision():
     pass

--- a/ims/picasso/rest.py
+++ b/ims/picasso/rest.py
@@ -82,16 +82,16 @@ def list_images():
 
 
 @rest_call("/provision/", 'PUT', constants.PROVISION_COMMAND,
-           [constants.HIL_OPTION_PARAMETER, constants.NODE_NAME_PARAMETER,
-            constants.IMAGE_NAME_PARAMETER, constants.NETWORK_PARAMETER,
-            constants.NIC_PARAMETER])
+           [constants.NODE_NAME_PARAMETER, constants.IMAGE_NAME_PARAMETER,
+            constants.NETWORK_PARAMETER, constants.NIC_PARAMETER,
+            constants.HIL_OPTION_PARAMETER])
 def provision():
     pass
 
 
 @rest_call("/deprovision/", "DELETE", constants.DEPROVISION_COMMAND,
-           [constants.HIL_OPTION_PARAMETER, constants.NODE_NAME_PARAMETER,
-            constants.NETWORK_PARAMETER, constants.NIC_PARAMETER])
+           [constants.NODE_NAME_PARAMETER, constants.NETWORK_PARAMETER,
+            constants.NIC_PARAMETER, constants.HIL_OPTION_PARAMETER])
 def deprovision():
     pass
 

--- a/ims/rpc/client/rpc_client.py
+++ b/ims/rpc/client/rpc_client.py
@@ -14,8 +14,8 @@ class RPCClient:
         # Loads the variable dict with the contents of config.json.
         self.dict = {
             "function-list": {
-                "provision": "4",
-                "deprovision": "3",
+                "provision": "5",
+                "deprovision": "4",
                 "create_snapshot": "2",
                 "list_images": "0",
                 "list_snapshots": "0",

--- a/tests/integration/einstein/test_operations.py
+++ b/tests/integration/einstein/test_operations.py
@@ -46,12 +46,12 @@ class TestProvision(TestCase):
 
     def runTest(self):
         response = self.good_bmi.provision(NODE_NAME, EXIST_IMG_NAME, NETWORK,
-                                           NIC)
+                                           NIC, "True")
         self.assertEqual(response[constants.STATUS_CODE_KEY], 200)
         time.sleep(constants.HAAS_CALL_TIMEOUT)
 
     def tearDown(self):
-        self.good_bmi.deprovision(NODE_NAME, NETWORK, NIC)
+        self.good_bmi.deprovision(NODE_NAME, NETWORK, NIC, "True")
         self.good_bmi.remove_image(EXIST_IMG_NAME)
         self.db.project.delete_with_name(PROJECT)
         self.db.close()
@@ -71,11 +71,13 @@ class TestDeprovision(TestCase):
         self.good_bmi = BMI(CORRECT_HIL_USERNAME, CORRECT_HIL_PASSWORD,
                             PROJECT)
         self.good_bmi.import_ceph_image(EXIST_IMG_NAME)
-        self.good_bmi.provision(NODE_NAME, EXIST_IMG_NAME, NETWORK, NIC)
+        self.good_bmi.provision(NODE_NAME, EXIST_IMG_NAME, NETWORK, NIC,
+                                "True")
         time.sleep(constants.HAAS_CALL_TIMEOUT)
 
     def runTest(self):
-        response = self.good_bmi.deprovision(NODE_NAME, NETWORK, NIC)
+        response = self.good_bmi.deprovision(NODE_NAME, NETWORK, NIC,
+                                             "True")
         self.assertEqual(response[constants.STATUS_CODE_KEY], 200)
         time.sleep(constants.HAAS_CALL_TIMEOUT)
 
@@ -98,7 +100,8 @@ class TestCreateSnapshot(TestCase):
         self.good_bmi = BMI(CORRECT_HIL_USERNAME, CORRECT_HIL_PASSWORD,
                             PROJECT)
         self.good_bmi.import_ceph_image(EXIST_IMG_NAME)
-        self.good_bmi.provision(NODE_NAME, EXIST_IMG_NAME, NETWORK, NIC)
+        self.good_bmi.provision(NODE_NAME, EXIST_IMG_NAME, NETWORK, NIC,
+                                "True")
         time.sleep(constants.HAAS_CALL_TIMEOUT)
 
     def runTest(self):
@@ -119,7 +122,7 @@ class TestCreateSnapshot(TestCase):
             fs.get_image(img_id)
 
     def tearDown(self):
-        self.good_bmi.deprovision(NODE_NAME, NETWORK, NIC)
+        self.good_bmi.deprovision(NODE_NAME, NETWORK, NIC, "True")
         self.good_bmi.remove_image(NEW_SNAP_NAME)
         self.good_bmi.remove_image(EXIST_IMG_NAME)
         self.db.project.delete_with_name(PROJECT)
@@ -140,7 +143,8 @@ class TestListSnapshots(TestCase):
         self.good_bmi = BMI(CORRECT_HIL_USERNAME, CORRECT_HIL_PASSWORD,
                             PROJECT)
         self.good_bmi.import_ceph_image(EXIST_IMG_NAME)
-        self.good_bmi.provision(NODE_NAME, EXIST_IMG_NAME, NETWORK, NIC)
+        self.good_bmi.provision(NODE_NAME, EXIST_IMG_NAME, NETWORK, NIC,
+                                "True")
         time.sleep(constants.HAAS_CALL_TIMEOUT)
 
         self.good_bmi.create_snapshot(NODE_NAME, NEW_SNAP_NAME)
@@ -152,7 +156,7 @@ class TestListSnapshots(TestCase):
                          NEW_SNAP_NAME)
 
     def tearDown(self):
-        self.good_bmi.deprovision(NODE_NAME, NETWORK, NIC)
+        self.good_bmi.deprovision(NODE_NAME, NETWORK, NIC, "True")
         self.good_bmi.remove_image(NEW_SNAP_NAME)
         self.good_bmi.remove_image(EXIST_IMG_NAME)
         self.db.project.delete_with_name(PROJECT)


### PR DESCRIPTION
Added the option to not have BMI call HIL to attach/detach the node from the network as Secure Cloud has their own specific way they want this attachment and detachment to occur.