### PR TITLE
run pep8 along with other scripts rather than before_script

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -11,6 +11,9 @@ services:
   - docker
 
 before_script:
+  # Run syntax checks before spawning the test environment
+  - find . -name \*.py -exec python -m py_compile {} +
+
   # Run Ceph Container and Wait for some time so that ceph runs
   - sudo docker run -d -v ceph:/etc/ceph -e MON_IP=172.17.0.2 -e CEPH_PUBLIC_NETWORK=172.17.0.0/24 --name ceph ceph/demo:tag-build-master-hammer-centos-7
   - sleep 30

--- a/.travis.yml
+++ b/.travis.yml
@@ -11,10 +11,6 @@ services:
   - docker
 
 before_script:
-  # Run pep8 on all .py files in all subfolders
-  # ignore E402: module level import not at top of file
-  - find . -name \*.py -exec pep8 --ignore=E402 {} +
-
   # Run Ceph Container and Wait for some time so that ceph runs
   - sudo docker run -d -v ceph:/etc/ceph -e MON_IP=172.17.0.2 -e CEPH_PUBLIC_NETWORK=172.17.0.0/24 --name ceph ceph/demo:tag-build-master-hammer-centos-7
   - sleep 30
@@ -34,6 +30,10 @@ before_script:
   - sudo docker exec bmi rbd create --image-format 2 --size 10 bmi_test
 
 script:
+  # Run pep8 on all .py files in all subfolders
+  # ignore E402: module level import not at top of file
+  - find . -name \*.py -exec pep8 --ignore=E402 {} +
+
   # Run Tests in BMI container
   - sudo docker exec bmi pytest -v --random-order-bucket=global --cov=ims tests/
 


### PR DESCRIPTION
* without this the build will fail and stop if pep8 tests fail. but we still want
to see if there are any other failures in the travis build so this would keep it going.

This [link](https://docs.travis-ci.com/user/customizing-the-build#Breaking-the-Build) has more info. Thanks @jeremyfreudberg